### PR TITLE
Use local yaml file to allow customizations

### DIFF
--- a/lib/valid_email.rb
+++ b/lib/valid_email.rb
@@ -1,5 +1,19 @@
 require 'valid_email/all'
+
 I18n.load_path += Dir.glob(File.expand_path('../../config/locales/**/*',__FILE__))
+
 # Load list of disposable email domains
-config = File.expand_path('../../config/valid_email.yml',__FILE__)
-BanDisposableEmailValidator.config= YAML.load_file(config)['disposable_email_services'] rescue []
+def config_file
+  return local_file if File.exist?(local_file)
+  gem_file
+end
+
+def local_file
+  File.expand_path('config/valid_email.yml', __FILE__)
+end
+
+def gem_file
+  File.expand_path('../../config/valid_email.yml', __FILE__)
+end
+
+BanDisposableEmailValidator.config = YAML.load_file(config_file)['disposable_email_services'] rescue []


### PR DESCRIPTION
By reading from the local file, it allows us to customize the file
directly in our repo, as opposed to relying on the gem maintainers to
do it. It's also possible that we might need to block some emails that
others won't want to block.
