### PR TITLE
Use local yaml file to allow customizations

### DIFF
--- a/lib/valid_email.rb
+++ b/lib/valid_email.rb
@@ -9,7 +9,7 @@ def config_file
 end
 
 def local_file
-  File.expand_path('config/valid_email.yml', __FILE__)
+  File.join(__dir__, 'valid_email.yml')
 end
 
 def gem_file


### PR DESCRIPTION
By reading from the local file, it allows us to customize the file
directly in our repo, as opposed to relying on the gem maintainers to
do it. It's also possible that we might need to block some emails that
others won't want to block.
